### PR TITLE
Type mismatch exception fix on LinkItemCollection ToEnumerable extension

### DIFF
--- a/Geta.EPi.Extensions/LinkItemCollectionExtensions.cs
+++ b/Geta.EPi.Extensions/LinkItemCollectionExtensions.cs
@@ -39,7 +39,8 @@ namespace Geta.EPi.Extensions
             return linkItemCollection
                 .Select(x => x.ToContentReference())
                 .Where(x => !x.IsNullOrEmpty())
-                .Select(contentLoader.Get<T>);
+                .Select(contentLoader.Get<IContent>)
+                .SafeOfType<T>();
         }
     }
 }


### PR DESCRIPTION
Current solution threw Type mismatch exception if loaded content type didn't match T. This solution always returns only content it type T. And doesn't throw if there is some link of different type.