### PR TITLE
Use X-Forwarded-Proto in external URLs if available

### DIFF
--- a/src/Geta.EPi.Extensions/StringExtensions.cs
+++ b/src/Geta.EPi.Extensions/StringExtensions.cs
@@ -62,6 +62,10 @@ namespace Geta.EPi.Extensions
                             ? HttpContext.Current.Request.Url
                             : SiteDefinition.Current.SiteUrl;
 
+            var scheme = HttpContext.Current != null && !string.IsNullOrEmpty(HttpContext.Current.Request.Headers["X-Forwarded-Proto"])
+                            ? HttpContext.Current.Request.Headers["X-Forwarded-Proto"]
+                            : siteUri.Scheme;
+
             if (!input.StartsWith("/"))
             {
                 input = "/" + input;
@@ -69,7 +73,7 @@ namespace Geta.EPi.Extensions
 
             var urlBuilder = new UrlBuilder(input)
             {
-                Scheme = siteUri.Scheme,
+                Scheme = scheme,
                 Host = siteUri.Host,
                 Port = siteUri.Port
             };


### PR DESCRIPTION
Load balancers often terminate SSL traffic and add the X-Forwarded-Proto header to pass the original request protocol to the backend servers. This change make sure that information is used when building external URLs. 