### PR TITLE
Handle multiple values in X-Forwarded-Proto when building URLs

### DIFF
--- a/src/Geta.EPi.Extensions/Helpers/UriHelpers.cs
+++ b/src/Geta.EPi.Extensions/Helpers/UriHelpers.cs
@@ -21,7 +21,7 @@ namespace Geta.EPi.Extensions.Helpers
                 : SiteDefinition.Current.SiteUrl;
 
             var scheme = HttpContext.Current != null && !string.IsNullOrEmpty(HttpContext.Current.Request.Headers["X-Forwarded-Proto"])
-                ? HttpContext.Current.Request.Headers["X-Forwarded-Proto"]
+                ? HttpContext.Current.Request.Headers["X-Forwarded-Proto"].Split(',')[0]
                 : siteUri.Scheme;
 
             var urlBuilder = new UrlBuilder(siteUri)


### PR DESCRIPTION
Ran into a problem when adding a CDN to a site where both the CDN and a load balancer added it's own X-Forwarded-Proto value. Similar to X-Forwarded-For the first value corresponds to the values for the request made by the client.